### PR TITLE
RequestingParty addition, updated to DATEXII_V3

### DIFF
--- a/wsdl/tp2-internal.wsdl
+++ b/wsdl/tp2-internal.wsdl
@@ -25,6 +25,7 @@
      </sequence>
     </complexType>
    <element name="saveTP2OK" type="impl:SaveTP2OK"/>
+   
    <complexType name="SaveTP2OKResponse">
      <sequence>
       <element name="return" type="boolean"/>
@@ -48,6 +49,43 @@
      </sequence>
     </complexType>
    <element name="getDGTDocumentResponse" type="impl:GetDGTDocumentResponse"/>
+
+   <complexType name="GetDynamicInformation">
+     <sequence>
+     	<element name="idTransportUnit" type="xsd:string" />
+     	<element name="countryCode" type="string"></element>
+     	<element name="requestReason" type="tns2:RequestReasonEnum" maxOccurs="1" minOccurs="1"></element>
+     	<element name="requestingParty" type="tns2:PublicService" maxOccurs="1" minOccurs="1"></element>
+     </sequence>
+   </complexType>
+   <element name="getDynamicInformation" type="impl:GetDynamicInformation"/>
+
+   <complexType name="GetDynamicInformationResponse">
+     <sequence>
+       <element name="dgPublication" type="dgt:DGPublication" />
+     </sequence>
+   </complexType>
+   <element name="getDynamicInformationResponse" type="impl:GetDynamicInformationResponse"/>
+
+    <complexType name="GetTransportUnitByArea">
+      <sequence>
+      	<element name="x" type="xsd:float" />
+      	<element name="y" type="xsd:float" />
+      	<element name="radius" type="xsd:int" />
+      	<element maxOccurs="1" minOccurs="1" name="requestReason"
+      		type="tns2:RequestReasonEnum" />
+      	<element name="requestingParty" type="tns2:PublicService" maxOccurs="1" minOccurs="1"></element>
+      </sequence>
+    </complexType>
+    <element name="getTransportUnitByArea" type="impl:GetTransportUnitByArea"/>
+
+    <complexType name="GetTransportUnitByAreaResponse">
+      <sequence minOccurs="0" maxOccurs="unbounded" >
+        <element name="idTransportUnit" type="xsd:string"/>
+        <element name="countryCode" type="xsd:string"/>
+      </sequence>
+    </complexType>
+    <element name="getTransportUnitByAreaResponse" type="impl:GetTransportUnitByAreaResponse"/>
   </schema>
   </wsdl:types>
 
@@ -71,18 +109,46 @@
     <wsdl:part element="impl:getDGTDocumentResponse" name="parameters">
     </wsdl:part>
   </wsdl:message>
+
+  <wsdl:message name="getDynamicInformationRequest">
+    <wsdl:part element="impl:getDynamicInformation" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getDynamicInformationResponseMessage">
+    <wsdl:part element="impl:getDynamicInformationResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+
+  <wsdl:message name="getTransportUnitByAreaRequest">
+    <wsdl:part element="impl:getTransportUnitByArea" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getTransportUnitByAreaResponseMessage">
+    <wsdl:part element="impl:getTransportUnitByAreaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
    
    <wsdl:portType name="TP2InternalServices">
       <wsdl:operation name="saveTP2OK">
          <wsdl:input message="impl:saveTP2OKRequestMessage"/>
          <wsdl:output message="impl:saveTP2OKResponseMessage"/>
 		<wsdl:fault message="impl:errorMessageFault" name="errorMessage"/> 
-      </wsdl:operation>
+    </wsdl:operation>
  
     <wsdl:operation name="getDGTDocument">
       <wsdl:input message="impl:getDGTDocumentRequestMessage"/>
       <wsdl:output message="impl:getDGTDocumentResponseMessage"/>
-      </wsdl:operation>
+    </wsdl:operation>
+
+    <wsdl:operation name="getDynamicInformation">
+      <wsdl:input message="impl:getDynamicInformationRequest"/>
+      <wsdl:output message="impl:getDynamicInformationResponseMessage"/>
+    </wsdl:operation>
+
+    <wsdl:operation name="getTransportUnitByArea">
+      <wsdl:input message="impl:getTransportUnitByAreaRequest"/>
+      <wsdl:output message="impl:getTransportUnitByAreaResponseMessage"/>
+    </wsdl:operation>
 
    </wsdl:portType>
    
@@ -104,6 +170,26 @@
   
     <wsdl:operation name="getDGTDocument">
       <wsdlsoap:operation soapAction="getDGTDocument" style="document"/>
+      <wsdl:input>
+        <wsdlsoap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <wsdlsoap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+
+    <wsdl:operation name="getDynamicInformation">
+      <wsdlsoap:operation soapAction="getDynamicInformation" style="document"/>
+      <wsdl:input>
+        <wsdlsoap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <wsdlsoap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+
+    <wsdl:operation name="getTransportUnitByArea">
+      <wsdlsoap:operation soapAction="getTransportUnitByArea" style="document"/>
       <wsdl:input>
         <wsdlsoap:body use="literal"/>
       </wsdl:input>

--- a/wsdl/tp2-internal.wsdl
+++ b/wsdl/tp2-internal.wsdl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<wsdl:definitions xmlns:apachesoap="http://xml.apache.org/xml-soap" xmlns:d2ns="http://datex2.eu/schema/2/2_0" xmlns:impl="http://dgtina.org/tp2/wsdl/tp2-internal/1.0" xmlns:intf="http://dgtina.org/tp2/wsdl/tp2-internal/1.0" xmlns:tns2="http://dgtina.org/exchange-model/schema/exchange-model/1.0" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://dgtina.org/tp2/wsdl/tp2-internal/1.0">
+<wsdl:definitions xmlns:apachesoap="http://xml.apache.org/xml-soap" xmlns:d2ns="http://datex2.eu/schema/3/d2Payload" xmlns:impl="http://dgtina.org/tp2/wsdl/tp2-internal/1.0" xmlns:intf="http://dgtina.org/tp2/wsdl/tp2-internal/1.0" xmlns:tns2="http://dgtina.org/exchange-model/schema/exchange-model/1.0" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://dgtina.org/tp2/wsdl/tp2-internal/1.0">
  <wsdl:types>
   <schema xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://dgtina.org/tp2/wsdl/tp2-internal/1.0">
-   <import namespace="http://datex2.eu/schema/2/2_0" schemaLocation="../../data-model/schema/DATEXIISchema_DGT_V2.xsd"/>
+   <import namespace="http://datex2.eu/schema/3/d2Payload" schemaLocation="../../data-model/schema/DATEXII_3_D2Payload.xsd"/>
    <import namespace="http://dgtina.org/exchange-model/schema/exchange-model/1.0" schemaLocation="../../exchange-model/schema/exchange-model.xsd"/>
 
    <complexType name="SaveTP2OK">
@@ -24,16 +24,17 @@
 
    <complexType name="GetDGTDocument">
      <sequence>
-      <element name="idTransportUnit" type="xsd:string"/>
-      <element name="countryCode" type="xsd:string"/>
-      <element maxOccurs="1" minOccurs="1" name="requestReason" type="tns2:RequestReasonEnum"/>
+     	<element name="idTransportUnit" type="xsd:string"/>
+     	<element name="countryCode" type="xsd:string"/>
+     	<element maxOccurs="1" minOccurs="1" name="requestReason" type="tns2:RequestReasonEnum"/>
+     	<element minOccurs="1" maxOccurs="1" name="requestingParty" type="tns2:PublicService"/>
      </sequence>
-    </complexType>
+   </complexType>
    <element name="getDGTDocument" type="impl:GetDGTDocument"/>
 
    <complexType name="GetDGTDocumentResponse">
      <sequence>
-      <element ref="d2ns:dgCarryingVehicle"/>
+      <element ref="d2ns:payload"/>
      </sequence>
     </complexType>
    <element name="getDGTDocumentResponse" type="impl:GetDGTDocumentResponse"/>

--- a/wsdl/tp2-internal.wsdl
+++ b/wsdl/tp2-internal.wsdl
@@ -79,10 +79,15 @@
     </complexType>
     <element name="getTransportUnitByArea" type="impl:GetTransportUnitByArea"/>
 
-    <complexType name="GetTransportUnitByAreaResponse">
-      <sequence minOccurs="0" maxOccurs="unbounded" >
-        <element name="idTransportUnit" type="xsd:string"/>
-        <element name="countryCode" type="xsd:string"/>
+    <complexType name="TransportUnitByAreaEntry">
+      <all>
+        <element name="idsTransportUnit" type="xsd:string" maxOccurs="1" minOccurs="1"/>
+        <element name="countryCode" type="string" maxOccurs="1" minOccurs="1"/>
+      </all>
+    </complexType>
+    <complexType name='GetTransportUnitByAreaResponse'>
+      <sequence>
+        <element minOccurs='0' maxOccurs='unbounded' name='getTransportUnitByAreaResponseList' type='impl:TransportUnitByAreaEntry'/>
       </sequence>
     </complexType>
     <element name="getTransportUnitByAreaResponse" type="impl:GetTransportUnitByAreaResponse"/>

--- a/wsdl/tp2-internal.wsdl
+++ b/wsdl/tp2-internal.wsdl
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<wsdl:definitions xmlns:apachesoap="http://xml.apache.org/xml-soap" xmlns:d2ns="http://datex2.eu/schema/3/d2Payload" xmlns:impl="http://dgtina.org/tp2/wsdl/tp2-internal/1.0" xmlns:intf="http://dgtina.org/tp2/wsdl/tp2-internal/1.0" xmlns:tns2="http://dgtina.org/exchange-model/schema/exchange-model/1.0" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://dgtina.org/tp2/wsdl/tp2-internal/1.0">
+<wsdl:definitions xmlns:apachesoap="http://xml.apache.org/xml-soap"
+  xmlns:d2ns="http://datex2.eu/schema/3/d2Payload"
+  xmlns:dgt="http://datex2.eu/schema/3/dangerousGoodsTransport"  
+  xmlns:impl="http://dgtina.org/tp2/wsdl/tp2-internal/1.0"
+  xmlns:intf="http://dgtina.org/tp2/wsdl/tp2-internal/1.0"
+  xmlns:tns2="http://dgtina.org/exchange-model/schema/exchange-model/1.0"
+  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://dgtina.org/tp2/wsdl/tp2-internal/1.0">
  <wsdl:types>
   <schema xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://dgtina.org/tp2/wsdl/tp2-internal/1.0">
    <import namespace="http://datex2.eu/schema/3/d2Payload" schemaLocation="../../data-model/schema/DATEXII_3_D2Payload.xsd"/>
+   <import namespace="http://datex2.eu/schema/3/dangerousGoodsTransport" schemaLocation="../../data-model/schema/DATEXII_3_DangerousGoodsTransport.xsd"/>
    <import namespace="http://dgtina.org/exchange-model/schema/exchange-model/1.0" schemaLocation="../../exchange-model/schema/exchange-model.xsd"/>
 
    <complexType name="SaveTP2OK">
@@ -34,7 +44,7 @@
 
    <complexType name="GetDGTDocumentResponse">
      <sequence>
-      <element ref="d2ns:payload"/>
+      <element name="dgPublication" type="dgt:DGPublication" />
      </sequence>
     </complexType>
    <element name="getDGTDocumentResponse" type="impl:GetDGTDocumentResponse"/>


### PR DESCRIPTION
Changes made with Jean-Philippe:
•	add areaOfCompetence to publicService object
•	change the GetDGTDocument method for "TP1 to TP1" and "TP1 to TP2" to be be able to transmit the information or the requesting party
•	reorganise the WSDL into 4 parts :
•	TP1-Authority-Services without the methods for TP2
•	TP1-TP1-Services
•	TP1-TP2-Services without the methods for authorities
•	TP2-internal
